### PR TITLE
[BUD-30] 소셜로그인 및 JWT 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ configurations {
     }
 }
 
+ext {
+    set('springCloudVersion', "2021.0.1")
+}
+
 repositories {
     mavenCentral()
 }
@@ -21,6 +25,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.30'
 
@@ -28,6 +34,19 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+    }
 }
 
 tasks.named('test') {

--- a/src/main/java/com/capstone/buddyvet/BuddyvetApplication.java
+++ b/src/main/java/com/capstone/buddyvet/BuddyvetApplication.java
@@ -2,8 +2,10 @@ package com.capstone.buddyvet;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class BuddyvetApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/capstone/buddyvet/common/auth/KakaoAuthService.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/KakaoAuthService.java
@@ -1,0 +1,52 @@
+package com.capstone.buddyvet.common.auth;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.capstone.buddyvet.common.auth.client.KakaoUserApiClient;
+import com.capstone.buddyvet.common.auth.dto.KakaoUserInfo;
+import com.capstone.buddyvet.domain.enums.Provider;
+import com.capstone.buddyvet.dto.Auth.LoginRequest;
+import com.capstone.buddyvet.dto.Auth.SocialUserInfo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KakaoAuthService {
+
+	@Value("${oauth2.kakao.admin-key}")
+	private String adminKey;
+
+	private final KakaoUserApiClient kakaoUserApiClient;
+
+	/**
+	 * 카카오 유저 정보 조회
+	 * @param loginRequest
+	 * @return 카카오 ID, 닉네임
+	 */
+	public Optional<SocialUserInfo> getUserInfo(LoginRequest loginRequest) {
+
+		KakaoUserInfo userInfo = kakaoUserApiClient.getUserInfo("Bearer " + loginRequest.getAccessToken());
+
+		return Optional.of(SocialUserInfo.builder()
+			.loginId(userInfo.getId())
+			.providerType(Provider.KAKAO)
+			.nickname(userInfo.getKakaoAccount().getProfile().getNickname())
+			.build());
+	}
+
+	/**
+	 * 카카오 회원탈퇴
+	 * @param targetId 카카오 ID
+	 */
+	public void revoke(String targetId) {
+		kakaoUserApiClient.unlinkUser("KakaoAK " + adminKey, "user_id", targetId);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/client/KakaoAuthClient.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/client/KakaoAuthClient.java
@@ -1,0 +1,18 @@
+package com.capstone.buddyvet.common.auth.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.capstone.buddyvet.common.auth.dto.KakaoToken;
+import com.capstone.buddyvet.common.config.FeignClientConfig;
+
+@FeignClient(name = "kakaoAuthClient", url = "https://kauth.kakao.com", configuration = FeignClientConfig.class)
+public interface KakaoAuthClient {
+
+	@PostMapping(value = "/oauth/token")
+	KakaoToken getToken(@RequestParam("client_id") String restApiKey,
+		@RequestParam("redirect_uri") String redirectUrl,
+		@RequestParam("code") String code,
+		@RequestParam("grant_type") String grantType);
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/client/KakaoFeignConfiguration.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/client/KakaoFeignConfiguration.java
@@ -1,0 +1,15 @@
+package com.capstone.buddyvet.common.auth.client;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import feign.Client;
+
+@Configuration
+public class KakaoFeignConfiguration {
+
+	@Bean
+	public Client feignClient() {
+		return new Client.Default(null, null);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/client/KakaoUserApiClient.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/client/KakaoUserApiClient.java
@@ -1,0 +1,22 @@
+package com.capstone.buddyvet.common.auth.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.capstone.buddyvet.common.auth.dto.KakaoUnlinkResponse;
+import com.capstone.buddyvet.common.auth.dto.KakaoUserInfo;
+import com.capstone.buddyvet.common.config.FeignClientConfig;
+
+@FeignClient(name = "kakaoClient", url = "https://kapi.kakao.com", configuration = FeignClientConfig.class)
+public interface KakaoUserApiClient {
+
+	@PostMapping("/v2/user/me")
+	KakaoUserInfo getUserInfo(@RequestHeader("Authorization") String accessToken);
+
+	@PostMapping("/v1/user/unlink")
+	KakaoUnlinkResponse unlinkUser(@RequestHeader("Authorization") String appAdminKey,
+		@RequestParam("target_id_type") String targetIdType,
+		@RequestParam("target_id") String targetId);
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoAccount.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoAccount.java
@@ -1,0 +1,19 @@
+package com.capstone.buddyvet.common.auth.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class KakaoAccount {
+	private Profile profile;
+	private String gender;
+	private String birthday;
+	private String email;
+
+	@Getter
+	@ToString
+	public class Profile {
+		private String nickname;
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoToken.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoToken.java
@@ -1,0 +1,25 @@
+package com.capstone.buddyvet.common.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoToken {
+    private String tokenType;
+    private String accessToken;
+    private String refreshToken;
+    private Long expiresIn;
+    private Long refreshTokenExpiresIn;
+
+    private KakaoToken(final String accessToken, final String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoUnlink.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoUnlink.java
@@ -1,0 +1,14 @@
+package com.capstone.buddyvet.common.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUnlink {
+	private String target_id_type;
+	private String target_id;
+
+	public KakaoUnlink(String target_id) {
+		this.target_id_type = "user_id";
+		this.target_id = target_id;
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoUnlinkResponse.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoUnlinkResponse.java
@@ -1,0 +1,8 @@
+package com.capstone.buddyvet.common.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUnlinkResponse {
+	private String id;
+}

--- a/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/capstone/buddyvet/common/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,18 @@
+package com.capstone.buddyvet.common.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+@ToString
+public class KakaoUserInfo {
+
+	private String id;
+	private KakaoAccount kakaoAccount;
+}

--- a/src/main/java/com/capstone/buddyvet/common/config/FeignClientConfig.java
+++ b/src/main/java/com/capstone/buddyvet/common/config/FeignClientConfig.java
@@ -1,0 +1,7 @@
+package com.capstone.buddyvet.common.config;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignClientConfig {
+}

--- a/src/main/java/com/capstone/buddyvet/common/enums/ErrorCode.java
+++ b/src/main/java/com/capstone/buddyvet/common/enums/ErrorCode.java
@@ -8,7 +8,16 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
-	DEFAULT_ERROR_CODE("5000", HttpStatus.INTERNAL_SERVER_ERROR, "기본 에러 메시지입니다.");
+	DEFAULT_ERROR_CODE("5000", HttpStatus.INTERNAL_SERVER_ERROR, "기본 에러 메시지입니다."),
+
+	// Auth 관련
+	OAUTH_PROVIDER_CONNECT_ERROR("1000", HttpStatus.NOT_FOUND, "소셜로그인 서버로부터 정보를 받아올 수 없습니다."),
+	LOAD_USER_ERROR("1001", HttpStatus.NOT_FOUND, "DB에 존재하지 않는 사용자입니다."),
+
+	// User 관련
+	DEACTIVATED_USER("3000", HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다.");
+
+
 
 	private final String code;
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/capstone/buddyvet/controller/AuthController.java
+++ b/src/main/java/com/capstone/buddyvet/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.capstone.buddyvet.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.capstone.buddyvet.dto.Auth.JwtResponse;
+import com.capstone.buddyvet.dto.Auth.LoginRequest;
+import com.capstone.buddyvet.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/oauth")
+public class AuthController {
+
+	private final AuthService authService;
+
+	/**
+	 * 로그인/회원가입
+	 * @param request AccessToken, Provider
+	 * @return jwt, 회원가입 시 201, 로그인 시 200
+	 */
+	@PostMapping("/login")
+	public ResponseEntity<JwtResponse> login(@RequestBody LoginRequest request) {
+		return authService.login(request);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/domain/User.java
+++ b/src/main/java/com/capstone/buddyvet/domain/User.java
@@ -16,9 +16,11 @@ import org.hibernate.annotations.ColumnDefault;
 
 import com.capstone.buddyvet.common.domain.BaseTimeEntity;
 import com.capstone.buddyvet.domain.enums.Provider;
+import com.capstone.buddyvet.domain.enums.RoleType;
 import com.capstone.buddyvet.domain.enums.UserState;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,7 +33,7 @@ public class User extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(nullable = false, length = 64)
+	@Column(length = 64)
 	private String nickname;
 
 	@Column(columnDefinition = "TEXT")
@@ -49,6 +51,9 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String socialId;
 
+	@Enumerated(EnumType.STRING)
+	private RoleType roleType;
+
 	private String fcmToken;
 
 	@Column(nullable = false, columnDefinition = "TINYINT(1)")
@@ -62,4 +67,18 @@ public class User extends BaseTimeEntity {
 
 	@OneToMany(mappedBy = "user")
 	private List<Post> posts = new ArrayList<>();
+
+	@Builder
+	public User(String socialId, String nickname) {
+		this.state = UserState.ACTIVE;
+		this.provider = Provider.KAKAO;
+		this.socialId = socialId;
+		this.nickname = nickname;
+		this.isAllowPush = false;
+		this.roleType = RoleType.USER;
+	}
+
+	public boolean isActivate() {
+		return this.state == UserState.ACTIVE;
+	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/enums/RoleType.java
+++ b/src/main/java/com/capstone/buddyvet/domain/enums/RoleType.java
@@ -1,0 +1,14 @@
+package com.capstone.buddyvet.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RoleType {
+	USER("ROLE_USER"),
+	ADMIN("ROLE_ADMIN"),
+	GUEST("ROLE_GUEST");
+
+	private final String code;
+}

--- a/src/main/java/com/capstone/buddyvet/dto/Auth.java
+++ b/src/main/java/com/capstone/buddyvet/dto/Auth.java
@@ -9,23 +9,32 @@ import lombok.Getter;
 @Getter
 public class Auth {
 
+	/**
+	 * 로그인/회원가입 Request
+	 */
 	@Getter
 	public static class LoginRequest {
 		private String accessToken;
 		private Provider providerType;
 	}
 
+	/**
+	 * 소셜 Provider 에서 받아온 유저 정보 DTO
+	 */
 	@Getter
 	@AllArgsConstructor
 	@Builder
-	public static class LoginResponse {
+	public static class SocialUserInfo {
 		private String loginId;
 		private Provider providerType;
 		private String nickname;
-		private String profileImage;
 	}
 
+	/**
+	 * 로그인/회원가입 jwt Response
+	 */
 	@Getter
+	@AllArgsConstructor
 	public static class JwtResponse {
 		private String jwt;
 	}

--- a/src/main/java/com/capstone/buddyvet/dto/Auth.java
+++ b/src/main/java/com/capstone/buddyvet/dto/Auth.java
@@ -1,0 +1,32 @@
+package com.capstone.buddyvet.dto;
+
+import com.capstone.buddyvet.domain.enums.Provider;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Auth {
+
+	@Getter
+	public static class LoginRequest {
+		private String accessToken;
+		private Provider providerType;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class LoginResponse {
+		private String loginId;
+		private Provider providerType;
+		private String nickname;
+		private String profileImage;
+	}
+
+	@Getter
+	public static class JwtResponse {
+		private String jwt;
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/repository/UserRepository.java
+++ b/src/main/java/com/capstone/buddyvet/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package com.capstone.buddyvet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.capstone.buddyvet.domain.User;
+import com.capstone.buddyvet.domain.enums.Provider;
+import com.capstone.buddyvet.domain.enums.UserState;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	@Query("select u from User u where u.provider = :provider and u.socialId = :socialId and u.state = :state")
+	Optional<User> findUserBySocialId(@Param("provider") Provider providerType, @Param("socialId") String socialId,
+		@Param("state") UserState state);
+}

--- a/src/main/java/com/capstone/buddyvet/security/CustomUserDetailsService.java
+++ b/src/main/java/com/capstone/buddyvet/security/CustomUserDetailsService.java
@@ -1,0 +1,42 @@
+package com.capstone.buddyvet.security;
+
+import java.util.Collections;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.capstone.buddyvet.common.enums.ErrorCode;
+import com.capstone.buddyvet.common.exception.RestApiException;
+import com.capstone.buddyvet.domain.User;
+import com.capstone.buddyvet.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component("userDetailsService")
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	@Transactional
+	public UserDetails loadUserByUsername(String userId) {
+		User user = userRepository.findById(Long.valueOf(userId))
+			.orElseThrow(() -> new RestApiException(ErrorCode.LOAD_USER_ERROR));
+		return createSecurityUser(userId, user);
+	}
+
+	private org.springframework.security.core.userdetails.User createSecurityUser(String userId, User user) {
+		if (!user.isActivate()) {
+			throw new RestApiException(ErrorCode.DEACTIVATED_USER);
+		}
+		return new org.springframework.security.core.userdetails.User(
+			userId, passwordEncoder.encode("password"),
+			Collections.singleton(new SimpleGrantedAuthority(user.getRoleType().getCode())));
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/capstone/buddyvet/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.capstone.buddyvet.security;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		// 필요한 권한이 존재하지 않는 경우 403 Forbidden 에러 리턴
+		response.sendError(HttpServletResponse.SC_FORBIDDEN);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/capstone/buddyvet/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.capstone.buddyvet.security;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+		// 유효한 자격증명을 제공하지 않고 접근하려 할 때 401 Unauthorized 에러 리턴
+		response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/security/JwtFilter.java
+++ b/src/main/java/com/capstone/buddyvet/security/JwtFilter.java
@@ -1,0 +1,60 @@
+package com.capstone.buddyvet.security;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	private final TokenProvider tokenProvider;
+
+
+	/**
+	 * 토큰 인증 정보를 SecurityContext 에 저장
+	 */
+	@Override
+	public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+		throws IOException, ServletException {
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)servletRequest;
+		String jwt = resolveToken(httpServletRequest);
+		String requestURI = httpServletRequest.getRequestURI();
+
+		if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+			Authentication authentication = tokenProvider.getAuthentication(jwt);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+			log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+		} else {
+			log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+		}
+
+		filterChain.doFilter(servletRequest, servletResponse);
+	}
+
+	/**
+	 * @param request
+	 * @return Request Header 에서 토큰 정보를 조회해서 반환
+	 */
+	private String resolveToken(HttpServletRequest request) {
+		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+			return bearerToken.substring(7);
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/security/JwtSecurityConfig.java
+++ b/src/main/java/com/capstone/buddyvet/security/JwtSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.capstone.buddyvet.security;
+
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+	private final TokenProvider tokenProvider;
+
+	@Override
+	public void configure(HttpSecurity http) {
+		JwtFilter customFilter = new JwtFilter(tokenProvider);
+		http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/security/SecurityConfig.java
+++ b/src/main/java/com/capstone/buddyvet/security/SecurityConfig.java
@@ -1,0 +1,69 @@
+package com.capstone.buddyvet.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity    //기본적인 Web 보안 활성화
+@EnableGlobalMethodSecurity(prePostEnabled = true)    //@PreAuthorize 어노테이션을 메소드 단위로 추가하기 위해 적용
+public class SecurityConfig {
+
+	private final TokenProvider tokenProvider;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+	public SecurityConfig(TokenProvider tokenProvider,
+		JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+		JwtAccessDeniedHandler jwtAccessDeniedHandler) {
+		this.tokenProvider = tokenProvider;
+		this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+		this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return (web) -> web.ignoring().antMatchers();
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf().disable()
+
+			.exceptionHandling()
+			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+			.accessDeniedHandler(jwtAccessDeniedHandler)
+
+			// h2-console 을 위한 설정 START
+			.and()
+			.headers()
+			.frameOptions()
+			.sameOrigin()
+
+			.and()
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)    // 세션을 사용하지 않기 때문에 세션 설정 STATELESS 로 설정
+
+			.and()
+			.authorizeRequests()    //HttpServletRequest를 사용하는 요청들에 대한 접근제한을 설정하겠다
+			.antMatchers("/api/**/oauth/**").permitAll()
+			.antMatchers("/api/**/weather").permitAll()
+			.anyRequest().permitAll()
+
+			.and()
+			.apply(new JwtSecurityConfig(tokenProvider));
+
+		return http.build();
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/security/TokenProvider.java
+++ b/src/main/java/com/capstone/buddyvet/security/TokenProvider.java
@@ -1,0 +1,117 @@
+package com.capstone.buddyvet.security;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class TokenProvider implements InitializingBean {
+
+	private static final String AUTHORITIES_KEY = "auth";
+
+	private final String secret;
+	private final long tokenValidityInSeconds;
+
+	private Key key;
+
+	public TokenProvider(
+		@Value("${jwt.secret}") String secret,
+		@Value("${jwt.token-validity-in-milliseconds}") long tokenValidityInSeconds) {
+
+		this.secret = secret;
+		this.tokenValidityInSeconds = tokenValidityInSeconds * 1000 * 300;
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		byte[] keyBytes = Decoders.BASE64.decode(secret);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	/**
+	 * Authentication 객체의 권한 정보를 이용해서 토큰을 생성
+	 * @param authentication
+	 * @return jwt
+	 */
+	public String createToken(Authentication authentication) {
+		String authorities = authentication.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+
+		long now = (new Date()).getTime();
+		Date validity = new Date(now + this.tokenValidityInSeconds);
+
+		return Jwts.builder()
+			.setSubject(authentication.getName())
+			.claim(AUTHORITIES_KEY, authorities)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.setExpiration(validity)	// 토큰 expire time 설정
+			.compact();
+	}
+
+	/**
+	 * 토큰 정보를 이용해 Authentication 객체 리턴
+	 * @param token
+	 * @return Authentication 객체
+	 */
+	public Authentication getAuthentication(String token) {
+		Claims claims = Jwts
+			.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+			.map(SimpleGrantedAuthority::new)
+			.collect(Collectors.toList());
+
+		User principal = new User(claims.getSubject(), "", authorities);
+
+		return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+	}
+
+	/**
+	 * 토큰 유효성 검증
+	 * @param token
+	 * @return 유효한 토큰이면 true, 유효하지 않으면 false 반환
+	 */
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+			log.info("잘못된 JWT 서명입니다.");
+		} catch (ExpiredJwtException e) {
+			log.info("만료된 JWT 토큰입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.info("지원되지 않는 JWT 토큰입니다.");
+		} catch (IllegalArgumentException e) {
+			log.info("JWT 토큰이 잘못되었습니다.");
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/service/AuthService.java
+++ b/src/main/java/com/capstone/buddyvet/service/AuthService.java
@@ -1,0 +1,78 @@
+package com.capstone.buddyvet.service;
+
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.capstone.buddyvet.common.auth.KakaoAuthService;
+import com.capstone.buddyvet.common.enums.ErrorCode;
+import com.capstone.buddyvet.common.exception.RestApiException;
+import com.capstone.buddyvet.domain.User;
+import com.capstone.buddyvet.domain.enums.UserState;
+import com.capstone.buddyvet.dto.Auth.JwtResponse;
+import com.capstone.buddyvet.dto.Auth.LoginRequest;
+import com.capstone.buddyvet.dto.Auth.SocialUserInfo;
+import com.capstone.buddyvet.repository.UserRepository;
+import com.capstone.buddyvet.security.TokenProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+	private final UserRepository userRepository;
+	private final UserService userService;
+	private final KakaoAuthService kakaoAuthService;
+	private final TokenProvider tokenProvider;
+	private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+	/**
+	 * 로그인/회원가입
+	 * @param request
+	 * @return jwt
+	 */
+	@Transactional
+	public ResponseEntity<JwtResponse> login(LoginRequest request) {
+		SocialUserInfo userInfo = kakaoAuthService.getUserInfo(request)
+			.orElseThrow(() -> new RestApiException(ErrorCode.OAUTH_PROVIDER_CONNECT_ERROR));
+
+		Optional<User> findUser = userRepository.findUserBySocialId(userInfo.getProviderType(),
+			userInfo.getLoginId(), UserState.ACTIVE);
+
+		User user = findUser.orElseGet(() -> userService.registerUser(userInfo));
+		String jwt = createJwt(user.getId().toString());
+
+		if (findUser.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.CREATED)
+				.body(new JwtResponse(jwt));
+		}
+		return ResponseEntity.ok(new JwtResponse(jwt));
+	}
+
+	/**
+	 * 유저 ID 에 해당하는 jwt 생성
+	 * @param userId
+	 * @return jwt
+	 */
+	private String createJwt(String userId) {
+
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+			userId, "password");
+
+		// loadUserByUsername 실행
+		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		return tokenProvider.createToken(authentication);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/service/UserService.java
+++ b/src/main/java/com/capstone/buddyvet/service/UserService.java
@@ -1,0 +1,33 @@
+package com.capstone.buddyvet.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.capstone.buddyvet.domain.User;
+import com.capstone.buddyvet.dto.Auth.SocialUserInfo;
+import com.capstone.buddyvet.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+
+	/**
+	 * 유저 회원가입
+	 * @param userInfo 소셜 유저 정보
+	 * @return 유저 저장 후 유저 엔티티 반환
+	 */
+	@Transactional
+	public User registerUser(SocialUserInfo userInfo) {
+		return userRepository.save(User.builder()
+			.socialId(userInfo.getLoginId())
+				.nickname(userInfo.getNickname())
+			.build());
+	}
+}


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
PR 요약 작성, 대상 이슈번호 작성.
* Feature #8 

## Update Summary
- Spring Security 적용
- 카카오 로그인 적용
- FeignClients 적용


## New/Edited policies
로그인/회원가입 요청 시 FeignClients 를 이용해 카카오 서버로부터 유저 정보를 조회,
서비스에 이미 가입되어 있는 유저인지 판단 후 JWT 를 생성해서 반환합니다.
생성된 JWT 가 헤더에 담겨 전송 시,
Spring Security filter 를 통해서 유효성을 검증하고 유저를 식별합니다.

## Resolved Issue
없음.

## Unresolved Issue
없음.

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [x] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [x] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [x] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.
