### PR TITLE
[BUD-27] 시연용 일기 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,11 +37,17 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+    // FeignClients
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // AWS S3 & File upload
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'commons-io:commons-io:2.11.0'
 }
 
 dependencyManagement {

--- a/src/main/java/com/capstone/buddyvet/common/enums/ErrorCode.java
+++ b/src/main/java/com/capstone/buddyvet/common/enums/ErrorCode.java
@@ -8,15 +8,24 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
-	DEFAULT_ERROR_CODE("5000", HttpStatus.INTERNAL_SERVER_ERROR, "기본 에러 메시지입니다."),
+	DEFAULT_ERROR_CODE("10000", HttpStatus.INTERNAL_SERVER_ERROR, "기본 에러 메시지입니다."),
 
 	// Auth 관련
 	OAUTH_PROVIDER_CONNECT_ERROR("1000", HttpStatus.NOT_FOUND, "소셜로그인 서버로부터 정보를 받아올 수 없습니다."),
 	LOAD_USER_ERROR("1001", HttpStatus.NOT_FOUND, "DB에 존재하지 않는 사용자입니다."),
+	INVALID_ACCESS("1002", HttpStatus.BAD_REQUEST, "잘못된 접근입니다."),
+
 
 	// User 관련
-	DEACTIVATED_USER("3000", HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다.");
+	DEACTIVATED_USER("3000", HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다."),
 
+	// Diary 관련
+	NOT_FOUND_DIARY("4000", HttpStatus.NOT_FOUND, "해당 아이디의 일기가 없습니다."),
+	NOT_FOUND_DIARY_IMAGE("4001", HttpStatus.NOT_FOUND, "해당 아이디의 이미지가 일기에 없습니다."),
+
+	// File 관련
+	FILE_CONVERT_ERROR("5000", HttpStatus.INTERNAL_SERVER_ERROR, "파일 변환에 실패했습니다."),
+	FILE_UPLOAD_ERROR("5001", HttpStatus.INTERNAL_SERVER_ERROR, "파일 서버 업로드에 실패했습니다.");
 
 
 	private final String code;

--- a/src/main/java/com/capstone/buddyvet/common/file/S3Uploader.java
+++ b/src/main/java/com/capstone/buddyvet/common/file/S3Uploader.java
@@ -87,9 +87,9 @@ public class S3Uploader {
 
 	private void removeNewFile(File targetFile) {
 		if (targetFile.delete()) {
-			log.debug("파일이 삭제되었습니다.");
+			log.info("파일이 삭제되었습니다.");
 		} else {
-			log.debug("파일이 삭제되지 못했습니다.");
+			log.warn("파일이 삭제되지 못했습니다.");
 		}
 	}
 }

--- a/src/main/java/com/capstone/buddyvet/common/file/S3Uploader.java
+++ b/src/main/java/com/capstone/buddyvet/common/file/S3Uploader.java
@@ -1,0 +1,95 @@
+package com.capstone.buddyvet.common.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.capstone.buddyvet.common.enums.ErrorCode;
+import com.capstone.buddyvet.common.exception.RestApiException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class S3Uploader {
+	private final AmazonS3Client amazonS3Client;
+
+	@Value("${cloud.server.local}")
+	private String uploadFolder;
+
+	@Value("${cloud.aws.s3.bucket.name}")
+	private String bucket;
+
+	@Value("${cloud.aws.s3.bucket.directory}")
+	private String bucketDirectory;
+
+	@Value("${cloud.aws.s3.url}")
+	private String awsUrl;
+
+	public List<String> uploadFiles(List<MultipartFile> files, String directory) {
+		List<String> uploadPaths = new ArrayList<>();
+
+		try {
+			for (MultipartFile file : files) {
+				File convertFile = convert(file)
+					.orElseThrow(() -> new RestApiException(ErrorCode.FILE_CONVERT_ERROR));
+				uploadPaths.add(upload(convertFile, directory));
+			}
+			return uploadPaths;
+		} catch (IOException e) {
+			throw new RestApiException(ErrorCode.FILE_UPLOAD_ERROR);
+		}
+	}
+
+	private Optional<File> convert(MultipartFile file) throws IOException {
+		String originalFilename = file.getOriginalFilename();
+		String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+
+		String newFilename = UUID.randomUUID().toString() + extension;
+		File convertFile = new File(uploadFolder, newFilename);
+		InputStream fileStream = file.getInputStream();
+		FileUtils.copyInputStreamToFile(fileStream, convertFile);
+
+		try {
+			file.transferTo(convertFile);
+			return Optional.of(convertFile);
+		} catch (IllegalStateException e) {
+			throw new RestApiException(ErrorCode.FILE_CONVERT_ERROR);
+		}
+	}
+
+	private String upload(File uploadFile, String dirName) {
+		String fileName = bucketDirectory + "/" + dirName + "/" + uploadFile.getName();
+		String uploadImageUrl = putS3(uploadFile, fileName);
+		removeNewFile(uploadFile);
+		return awsUrl + fileName;
+	}
+
+	private String putS3(File uploadFile, String fileName) {
+		amazonS3Client.putObject(
+			new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(CannedAccessControlList.PublicRead));
+		return amazonS3Client.getUrl(bucket, fileName).toString();
+	}
+
+	private void removeNewFile(File targetFile) {
+		if (targetFile.delete()) {
+			log.debug("파일이 삭제되었습니다.");
+		} else {
+			log.debug("파일이 삭제되지 못했습니다.");
+		}
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/controller/DiaryController.java
+++ b/src/main/java/com/capstone/buddyvet/controller/DiaryController.java
@@ -1,0 +1,98 @@
+package com.capstone.buddyvet.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.capstone.buddyvet.common.dto.ResponseDto;
+import com.capstone.buddyvet.dto.Diary.AddRequest;
+import com.capstone.buddyvet.dto.Diary.AddResponse;
+import com.capstone.buddyvet.dto.Diary.DetailResponse;
+import com.capstone.buddyvet.dto.Diary.ImageRemoveRequest;
+import com.capstone.buddyvet.dto.Example.DiariesResponse;
+import com.capstone.buddyvet.service.DiaryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/diary")
+public class DiaryController {
+
+	private final DiaryService diaryService;
+
+	/**
+	 * 일기 목록 조회
+	 * @return 작성된 일기 목록
+	 * TODO Ex 에서 실제 구현으로 변경
+	 */
+	@GetMapping
+	public ResponseDto<DiariesResponse> diaryListEx() {
+		return new ResponseDto<>(diaryService.getDiaries());
+	}
+
+	/**
+	 * 일기 상세 조회
+	 * @param diaryId 조회활 일기 ID
+	 * @return ID 에 해당하는 일기 상세 정보
+	 */
+	@GetMapping("/{diaryId}")
+	public ResponseDto<DetailResponse> diaryDetails(@PathVariable Long diaryId) {
+		return new ResponseDto<>(diaryService.getDiary(diaryId));
+	}
+
+	/**
+	 * 일기 신규 작성
+	 * @param request 신규 작성할 일기 정보
+	 * @return 신규 생성된 일기 ID
+	 */
+	@PostMapping
+	public ResponseDto<AddResponse> diaryAdd(@RequestBody AddRequest request) {
+		return new ResponseDto<>(diaryService.addDiary(request));
+	}
+
+	/**
+	 * 일기 삭제
+	 * @param diaryId 삭제할 일기 ID
+	 * @return null
+	 */
+	@DeleteMapping("/{diaryId}")
+	public ResponseDto diaryRemove(@PathVariable Long diaryId) {
+		diaryService.removeDiary(diaryId);
+		return new ResponseDto(null);
+	}
+
+	/**
+	 * 일기 사진 업로드
+	 * @param diaryId 사진 추가할 일기 ID
+	 * @param files 업로드할 사진 리스트
+	 * @return null
+	 */
+	@PostMapping("/{diaryId}/image")
+	public ResponseDto imageUpload(@PathVariable Long diaryId, @RequestParam("image") List<MultipartFile> files) {
+		diaryService.uploadImage(diaryId, files);
+		return new ResponseDto(null);
+	}
+
+	/**
+	 * 일기 사진 삭제
+	 * @param diaryId 사진이 속해있는 일기 ID
+	 * @param request 삭제할 사진 ID
+	 * @return null
+	 */
+	@DeleteMapping("/{diaryId}/image")
+	public ResponseDto imageRemove(@PathVariable Long diaryId, @RequestBody ImageRemoveRequest request) {
+		diaryService.removeImage(diaryId, request.getImageId());
+		return new ResponseDto(null);
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/domain/Post.java
+++ b/src/main/java/com/capstone/buddyvet/domain/Post.java
@@ -51,6 +51,7 @@ public class Post extends BaseTimeEntity {
 	private String content;
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "CHAR(8)")
 	private PostState state;
 
 	@Builder

--- a/src/main/java/com/capstone/buddyvet/domain/Post.java
+++ b/src/main/java/com/capstone/buddyvet/domain/Post.java
@@ -1,17 +1,26 @@
 package com.capstone.buddyvet.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 
 import com.capstone.buddyvet.common.domain.BaseTimeEntity;
+import com.capstone.buddyvet.domain.enums.PostState;
+import com.capstone.buddyvet.dto.Diary;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,9 +37,28 @@ public class Post extends BaseTimeEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
+	@OneToMany(mappedBy = "post")
+	private List<PostImage> postImage = new ArrayList<>();
+
 	@Column(nullable = false, columnDefinition = "VARCHAR(128)")
 	private String title;
 
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
+
+	@Enumerated(EnumType.STRING)
+	private PostState state;
+
+	@Builder
+	public Post(User user, String title, String content) {
+		this.user = user;
+		this.title = title;
+		this.content = content;
+		this.state = PostState.ACTIVE;
+	}
+
+	//==비즈니스 로직==//
+	public void delete() {
+		this.state = PostState.DELETED;
+	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/Post.java
+++ b/src/main/java/com/capstone/buddyvet/domain/Post.java
@@ -1,8 +1,10 @@
 package com.capstone.buddyvet.domain;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -17,7 +19,6 @@ import javax.persistence.OneToMany;
 
 import com.capstone.buddyvet.common.domain.BaseTimeEntity;
 import com.capstone.buddyvet.domain.enums.PostState;
-import com.capstone.buddyvet.dto.Diary;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,8 +38,11 @@ public class Post extends BaseTimeEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@OneToMany(mappedBy = "post")
-	private List<PostImage> postImage = new ArrayList<>();
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
+	private List<PostImage> postImages = new ArrayList<>();
+
+	@Column(nullable = false)
+	private LocalDate date;
 
 	@Column(nullable = false, columnDefinition = "VARCHAR(128)")
 	private String title;
@@ -50,8 +54,9 @@ public class Post extends BaseTimeEntity {
 	private PostState state;
 
 	@Builder
-	public Post(User user, String title, String content) {
+	public Post(User user, LocalDate date, String title, String content) {
 		this.user = user;
+		this.date = date;
 		this.title = title;
 		this.content = content;
 		this.state = PostState.ACTIVE;
@@ -60,5 +65,10 @@ public class Post extends BaseTimeEntity {
 	//==비즈니스 로직==//
 	public void delete() {
 		this.state = PostState.DELETED;
+	}
+
+	public void saveImage(PostImage postImage) {
+		this.postImages.add(postImage);
+		postImage.setPost(this);
 	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/PostImage.java
+++ b/src/main/java/com/capstone/buddyvet/domain/PostImage.java
@@ -17,6 +17,7 @@ import com.capstone.buddyvet.common.domain.BaseTimeEntity;
 import com.capstone.buddyvet.domain.enums.ImageState;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,8 +42,17 @@ public class PostImage extends BaseTimeEntity {
 	@Column(nullable = false, columnDefinition = "CHAR(8)")
 	private ImageState state;
 
+	public PostImage(String url) {
+		this.url = url;
+		this.state = ImageState.ACTIVE;
+	}
+
 	//==비즈니스 로직==//
 	public void delete() {
 		state = ImageState.DELETED;
+	}
+
+	public void setPost(Post post) {
+		this.post = post;
 	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/PostImage.java
+++ b/src/main/java/com/capstone/buddyvet/domain/PostImage.java
@@ -40,4 +40,9 @@ public class PostImage extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, columnDefinition = "CHAR(8)")
 	private ImageState state;
+
+	//==비즈니스 로직==//
+	public void delete() {
+		state = ImageState.DELETED;
+	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/UserDiary.java
+++ b/src/main/java/com/capstone/buddyvet/domain/UserDiary.java
@@ -1,10 +1,14 @@
 package com.capstone.buddyvet.domain;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,8 +18,10 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
 import com.capstone.buddyvet.common.domain.BaseTimeEntity;
+import com.capstone.buddyvet.domain.enums.DiaryState;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -33,11 +39,36 @@ public class UserDiary extends BaseTimeEntity {
 	private User user;
 
 	@Column(nullable = false)
+	private LocalDate date;
+
+	@Column(nullable = false)
 	private String title;
 
 	@Column(nullable = false, columnDefinition = "TEXT")
 	private String content;
 
-	@OneToMany(mappedBy = "userDiary")
+	@OneToMany(mappedBy = "userDiary", cascade = CascadeType.ALL)
 	private List<UserDiaryImage> userDiaryImages = new ArrayList<>();
+
+	@Enumerated(EnumType.STRING)
+	private DiaryState state;
+
+	@Builder
+	public UserDiary(User user, LocalDate date, String title, String content) {
+		this.user = user;
+		this.date = date;
+		this.title = title;
+		this.content = content;
+		this.state = DiaryState.ACTIVE;
+	}
+
+	//==비즈니스 로직==//
+	public void delete() {
+		this.state = DiaryState.DELETED;
+	}
+
+	public void saveImage(UserDiaryImage diaryImage) {
+		this.userDiaryImages.add(diaryImage);
+		diaryImage.setDiary(this);
+	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/UserDiary.java
+++ b/src/main/java/com/capstone/buddyvet/domain/UserDiary.java
@@ -51,6 +51,7 @@ public class UserDiary extends BaseTimeEntity {
 	private List<UserDiaryImage> userDiaryImages = new ArrayList<>();
 
 	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, columnDefinition = "CHAR(8)")
 	private DiaryState state;
 
 	@Builder

--- a/src/main/java/com/capstone/buddyvet/domain/UserDiaryImage.java
+++ b/src/main/java/com/capstone/buddyvet/domain/UserDiaryImage.java
@@ -40,4 +40,18 @@ public class UserDiaryImage extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false, columnDefinition = "CHAR(8)")
 	private ImageState state;
+
+	public UserDiaryImage(String url) {
+		this.url = url;
+		this.state = ImageState.ACTIVE;
+	}
+
+	//==비즈니스 로직==//
+	public void delete() {
+		state = ImageState.DELETED;
+	}
+
+	public void setDiary(UserDiary userDiary) {
+		this.userDiary = userDiary;
+	}
 }

--- a/src/main/java/com/capstone/buddyvet/domain/enums/DiaryState.java
+++ b/src/main/java/com/capstone/buddyvet/domain/enums/DiaryState.java
@@ -1,0 +1,5 @@
+package com.capstone.buddyvet.domain.enums;
+
+public enum DiaryState {
+	ACTIVE, DELETED
+}

--- a/src/main/java/com/capstone/buddyvet/domain/enums/PostState.java
+++ b/src/main/java/com/capstone/buddyvet/domain/enums/PostState.java
@@ -1,0 +1,5 @@
+package com.capstone.buddyvet.domain.enums;
+
+public enum PostState {
+	ACTIVE, DELETED
+}

--- a/src/main/java/com/capstone/buddyvet/dto/Diary.java
+++ b/src/main/java/com/capstone/buddyvet/dto/Diary.java
@@ -1,0 +1,91 @@
+package com.capstone.buddyvet.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.capstone.buddyvet.domain.User;
+import com.capstone.buddyvet.domain.UserDiary;
+import com.capstone.buddyvet.domain.UserDiaryImage;
+import com.capstone.buddyvet.domain.enums.ImageState;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Diary {
+
+	/**
+	 * 신규 작성 Request
+	 */
+	@Getter
+	public static class AddRequest {
+		private LocalDate date;
+		private String title;
+		private String content;
+
+		//==DTO 변환 메소드==//
+		public UserDiary toEntity(User user) {
+			return UserDiary.builder()
+				.user(user)
+				.date(date)
+				.title(title)
+				.content(content)
+				.build();
+		}
+	}
+
+	/**
+	 * 신규 작성 Response
+	 */
+	@Getter
+	@AllArgsConstructor
+	public static class AddResponse {
+		private Long diaryId;
+	}
+
+	/**
+	 * 상세 조회 Response
+	 */
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class DetailResponse {
+		private LocalDate date;
+		private String title;
+		private List<Image> images;
+		private String content;
+
+		@Getter
+		public static class Image {
+			private Long id;
+			private String url;
+
+			public Image(UserDiaryImage diaryImage) {
+				this.id = diaryImage.getId();
+				this.url = diaryImage.getUrl();
+			}
+		}
+
+		//==DTO 변환 메소드==//
+		public static DetailResponse of(UserDiary diary) {
+			return DetailResponse.builder()
+				.date(diary.getDate())
+				.title(diary.getTitle())
+				.images(
+					diary.getUserDiaryImages().stream()
+						.filter(diaryImage -> diaryImage.getState() == ImageState.ACTIVE)
+						.map(Image::new)
+						.collect(Collectors.toList())
+				)
+				.content(diary.getContent())
+				.build();
+		}
+	}
+
+	@Getter
+	public static class ImageRemoveRequest {
+		private Long imageId;
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/dto/Example.java
+++ b/src/main/java/com/capstone/buddyvet/dto/Example.java
@@ -1,0 +1,37 @@
+package com.capstone.buddyvet.dto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.capstone.buddyvet.domain.UserDiary;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Example {
+
+	@Getter
+	public static class DiariesResponse {
+		private List<Info> diaries;
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		public static class Info {
+			private Long diaryId;
+			private String thumbnail;
+
+			public Info(UserDiary diary) {
+				this.diaryId = diary.getId();
+			}
+		}
+
+		public DiariesResponse(List<UserDiary> diaries) {
+			this.diaries = diaries.stream()
+				.map(Info::new)
+				.collect(Collectors.toList());
+		}
+	}
+}

--- a/src/main/java/com/capstone/buddyvet/repository/DiaryImageRepository.java
+++ b/src/main/java/com/capstone/buddyvet/repository/DiaryImageRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.buddyvet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.capstone.buddyvet.domain.UserDiaryImage;
+import com.capstone.buddyvet.domain.enums.ImageState;
+
+public interface DiaryImageRepository extends JpaRepository<UserDiaryImage, Long> {
+	Optional<UserDiaryImage> findByIdAndState(Long id, ImageState state);
+}

--- a/src/main/java/com/capstone/buddyvet/repository/DiaryRepository.java
+++ b/src/main/java/com/capstone/buddyvet/repository/DiaryRepository.java
@@ -1,0 +1,13 @@
+package com.capstone.buddyvet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.capstone.buddyvet.domain.UserDiary;
+import com.capstone.buddyvet.domain.enums.DiaryState;
+
+public interface DiaryRepository extends JpaRepository<UserDiary, Long> {
+	Optional<UserDiary> findByIdAndState(Long id, DiaryState state);
+
+}

--- a/src/main/java/com/capstone/buddyvet/repository/PostImageRepository.java
+++ b/src/main/java/com/capstone/buddyvet/repository/PostImageRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.buddyvet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.capstone.buddyvet.domain.PostImage;
+import com.capstone.buddyvet.domain.enums.ImageState;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+	Optional<PostImage> findByIdAndState(Long id, ImageState state);
+}

--- a/src/main/java/com/capstone/buddyvet/repository/PostRepository.java
+++ b/src/main/java/com/capstone/buddyvet/repository/PostRepository.java
@@ -1,0 +1,12 @@
+package com.capstone.buddyvet.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.capstone.buddyvet.domain.Post;
+import com.capstone.buddyvet.domain.enums.PostState;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+	Optional<Post> findByIdAndState(Long id, PostState state);
+}

--- a/src/main/java/com/capstone/buddyvet/security/SecurityUtil.java
+++ b/src/main/java/com/capstone/buddyvet/security/SecurityUtil.java
@@ -1,0 +1,43 @@
+package com.capstone.buddyvet.security;
+
+import java.util.Optional;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SecurityUtil {
+
+  /**
+   * jwt 를 이용해 현재 로그인 유저를 판단
+   * @return 현재 SecurityContext 에 저장된 username
+   */
+  public static Optional<String> getCurrentUsername() {
+
+    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    if (authentication == null) {
+      log.debug("Security Context에 인증 정보가 없습니다.");
+      return Optional.empty();
+    }
+
+    String username = null;
+    if (authentication.getPrincipal() instanceof UserDetails) {
+      UserDetails springSecurityUser = (UserDetails)authentication.getPrincipal();
+      username = springSecurityUser.getUsername();
+    } else if (authentication.getPrincipal() instanceof String) {
+      username = (String)authentication.getPrincipal();
+    }
+
+    return Optional.ofNullable(username);
+  }
+}
+

--- a/src/main/java/com/capstone/buddyvet/service/AuthService.java
+++ b/src/main/java/com/capstone/buddyvet/service/AuthService.java
@@ -20,6 +20,7 @@ import com.capstone.buddyvet.dto.Auth.JwtResponse;
 import com.capstone.buddyvet.dto.Auth.LoginRequest;
 import com.capstone.buddyvet.dto.Auth.SocialUserInfo;
 import com.capstone.buddyvet.repository.UserRepository;
+import com.capstone.buddyvet.security.SecurityUtil;
 import com.capstone.buddyvet.security.TokenProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -74,5 +75,16 @@ public class AuthService {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		return tokenProvider.createToken(authentication);
+	}
+
+	/**
+	 * 현재 로그인 유저 반환
+	 * @return 현재 jwt 로 SecurityContext 에 저장된 id 를 이용해 유저 엔티티 조회 후 반환
+	 * 없을 시 LOAD_USER_ERROR exception
+	 */
+	public User getCurrentUser() {
+		return SecurityUtil.getCurrentUsername()
+			.flatMap(id -> userRepository.findById(Long.valueOf(id)))
+			.orElseThrow(() -> new RestApiException(ErrorCode.LOAD_USER_ERROR));
 	}
 }

--- a/src/main/java/com/capstone/buddyvet/service/BuddyService.java
+++ b/src/main/java/com/capstone/buddyvet/service/BuddyService.java
@@ -2,11 +2,10 @@ package com.capstone.buddyvet.service;
 
 import org.springframework.stereotype.Service;
 
-import com.capstone.buddyvet.common.dto.ResponseDto;
-import com.capstone.buddyvet.dto.Buddy.SaveRequest;
-import com.capstone.buddyvet.dto.Buddy.SaveResponse;
 import com.capstone.buddyvet.dto.Buddy.BuddiesResponse;
 import com.capstone.buddyvet.dto.Buddy.DetailResponse;
+import com.capstone.buddyvet.dto.Buddy.SaveRequest;
+import com.capstone.buddyvet.dto.Buddy.SaveResponse;
 import com.capstone.buddyvet.repository.BuddyRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/capstone/buddyvet/service/DiaryService.java
+++ b/src/main/java/com/capstone/buddyvet/service/DiaryService.java
@@ -1,0 +1,119 @@
+package com.capstone.buddyvet.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.capstone.buddyvet.common.enums.ErrorCode;
+import com.capstone.buddyvet.common.exception.RestApiException;
+import com.capstone.buddyvet.common.file.S3Uploader;
+import com.capstone.buddyvet.domain.User;
+import com.capstone.buddyvet.domain.UserDiary;
+import com.capstone.buddyvet.domain.UserDiaryImage;
+import com.capstone.buddyvet.domain.enums.DiaryState;
+import com.capstone.buddyvet.domain.enums.ImageState;
+import com.capstone.buddyvet.dto.Diary.AddRequest;
+import com.capstone.buddyvet.dto.Diary.AddResponse;
+import com.capstone.buddyvet.dto.Diary.DetailResponse;
+import com.capstone.buddyvet.dto.Example.DiariesResponse;
+import com.capstone.buddyvet.repository.DiaryImageRepository;
+import com.capstone.buddyvet.repository.DiaryRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+
+	private final AuthService authService;
+	private final DiaryRepository diaryRepository;
+	private final DiaryImageRepository diaryImageRepository;
+	private final S3Uploader s3Uploader;
+
+	public DiariesResponse getDiaries() {
+		return new DiariesResponse(authService.getCurrentUser().getUserDiaries());
+	}
+
+	public DetailResponse getDiary(Long diaryId) {
+		UserDiary diary = getDiaryAndValidate(diaryId);
+
+		validateDiaryUser(diary);
+		return DetailResponse.of(diary);
+	}
+
+	@Transactional
+	public AddResponse addDiary(AddRequest request) {
+		UserDiary savedDiary = diaryRepository.save(request.toEntity(authService.getCurrentUser()));
+		return new AddResponse(savedDiary.getId());
+	}
+
+	@Transactional
+	public void removeDiary(Long diaryId) {
+		UserDiary diary = getDiaryAndValidate(diaryId);
+		validateDiaryUser(diary);
+		diary.delete();
+	}
+
+	@Transactional
+	public void uploadImage(Long diaryId, List<MultipartFile> files) {
+		UserDiary diary = getDiaryAndValidate(diaryId);
+		validateDiaryUser(diary);
+
+		User currentUser = authService.getCurrentUser();
+		List<String> urls = s3Uploader.uploadFiles(files, currentUser.getId().toString());
+
+		for (String url : urls) {
+			diary.saveImage(new UserDiaryImage(url));
+		}
+	}
+
+	@Transactional
+	public void removeImage(Long diaryId, Long imageId) {
+		UserDiary diary = getDiaryAndValidate(diaryId);
+		UserDiaryImage diaryImage = diaryImageRepository.findByIdAndState(imageId, ImageState.ACTIVE)
+			.orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_DIARY_IMAGE));
+
+		validateDiaryImageUser(diary, diaryImage);
+		diaryImage.delete();
+	}
+
+	/**
+	 * 해당 일기장이 현재 로그인 유저의 일기인지 검증
+	 * @param diary 검증할 일기
+	 *             현재 유저의 id 와 일기를 작성한 유저의 id 가 일치하지 않으면 exception
+	 */
+	private void validateDiaryUser(UserDiary diary) {
+		if (diary.getUser().getId() != authService.getCurrentUser().getId()) {
+			throw new RestApiException(ErrorCode.INVALID_ACCESS);
+		}
+	}
+
+	/**
+	 * 해당 사진이 파라미터로 전달된 일기글에 속해있는지, 현재 로그인 유저의 일기인지 검증
+	 * @param diary 검증할 일기
+	 * @param diaryImage 검증할 일기 사진
+	 *                  로그인 유저 validation,
+	 *                  파라미터로 전송된 일기글 id 와 사진이 속해있는 일기글 id 가 일치하지 않으면 exception
+	 */
+	private void validateDiaryImageUser(UserDiary diary, UserDiaryImage diaryImage) {
+		validateDiaryUser(diary);
+		if (diaryImage.getUserDiary().getId() != diary.getId()) {
+			throw new RestApiException(ErrorCode.INVALID_ACCESS);
+		}
+	}
+
+	/**
+	 * 일기 ID 로 일기 엔티티 조회
+	 * @param diaryId 조회할 일기 ID
+	 * @return ID 에 해당하는 일기 엔티티
+	 */
+	private UserDiary getDiaryAndValidate(Long diaryId) {
+		return diaryRepository.findByIdAndState(diaryId, DiaryState.ACTIVE)
+			.orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND_DIARY));
+	}
+}


### PR DESCRIPTION
## Update
- [ ] Hot Fix
- [ ] Release
- [x] Develop
- [ ] Others

## Description
PR 요약 작성, 대상 이슈번호 작성.
* Feature #12 

## Update Summary
일기 관련 API 추가. 

## New/Edited policies
- 일기 목록 조회 (부분완성)
- 일기 상세 조회
- 일기 작성
- 일기 삭제
- 일기 사진 업로드
- 일기 사진 삭제

## Resolved Issue
- AWS SDK 문제 : IAM Access Key 발급으로 해결
- OneToMany 의 경우 Cascade Type을 이용해서 변경사항 persist 시 적용되도록 조치

## Unresolved Issue
일기 목록 조회의 경우 년,월 마다 다른 리스트를 줘야 할 수 있고,
페이징 처리가 필요할 수도 있어 별도의 DTO 로 분리하여 example json 을 주도록 임시 조치함.

## Test
- [ ] 유닛 테스트
- [ ] 빌드 테스트 (통합 테스트)
- [x] 기타 유효성 테스트

## Proof Check
- [x] 코드가 이 프로젝트의 스타일 지침을 따릅니다.
- [x] 코드에 대한 자체 리뷰를 수행했습니다.
- [x] 변경 내역에 대해 주석을 작성했습니다.
- [ ] 해당 PR에 대한 문서를 변경했습니다.
- [ ] 기능, 정책 또는 수정 사항에 대한 테스트 코드를 추가했습니다.
- [x] 변경 내용이 로컬 개발환경에서의 테스트를 통과했습니다.
- [ ] 모든 종속 변경 사항이 병합되어 다운스트림 모듈에 게시되었습니다.
